### PR TITLE
[PP-58] Backend Endpoint to Calculate Vault Values

### DIFF
--- a/backend/async_backend.py
+++ b/backend/async_backend.py
@@ -1,11 +1,33 @@
 import aiohttp
 import asyncio
 import re
+import json
 from typing import Dict, List, Any
+import os
+from dotenv import load_dotenv
 
-async def get_owned_objects(session: aiohttp.ClientSession, network: str, owner: str) -> List[Dict[str, Any]]:
+load_dotenv()
+
+def load_config() -> Dict[str, Any]:
     """
-    Asynchronously retrieve owned objects for a given owner on a specified network.
+    Load configuration from the config file.
+    
+    Returns:
+        Dict[str, Any]: Configuration containing all fields from the config file
+    """
+    try:
+        config_file_path = os.environ.get('CONFIG_FILE_PATH', "")
+        
+        with open(config_file_path, 'r') as f:
+            config = json.load(f)
+            return config
+    except Exception as e:
+        raise RuntimeError(f"Failed to load config file: {str(e)}")
+
+
+async def get_owned_objects(session: aiohttp.ClientSession, sui_api_url: str, owner: str) -> List[Dict[str, Any]]:
+    """
+    Asynchronously retrieve owned objects for a given owner.
     """
     request = {
         "jsonrpc": "2.0",
@@ -27,16 +49,17 @@ async def get_owned_objects(session: aiohttp.ClientSession, network: str, owner:
         ]
     }
     
-    async with session.post(f'https://fullnode.{network}.sui.io:443', json=request) as response:
+    async with session.post(sui_api_url, json=request) as response:
         result = await response.json()
         owned_objects = result['result']['data']
         return owned_objects
 
-async def get_collateral_objects(session: aiohttp.ClientSession, network: str, owner: str, account: str, contract_address: str) -> List[Dict[str, Any]]:
+
+async def get_collateral_objects(session: aiohttp.ClientSession, sui_api_url: str, owner: str, account: str, contract_address: str) -> List[Dict[str, Any]]:
     """
     Asynchronously retrieve collateral objects owned by a specified owner.
     """
-    owned_objects = await get_owned_objects(session, network, owner)
+    owned_objects = await get_owned_objects(session, sui_api_url, owner)
     collateral_objects = []
     
     type_regex = rf"{contract_address}\w*::collateral::Collateral<(0x\w*::\S*::\S*)>"
@@ -50,12 +73,13 @@ async def get_collateral_objects(session: aiohttp.ClientSession, network: str, o
             
     return collateral_objects
 
-async def form_coin_type_prgm_triples(session: aiohttp.ClientSession, network: str, owner: str, account: str, contract_address: str) -> List[Dict[str, str]]:
+
+async def form_coin_type_prgm_triples(session: aiohttp.ClientSession, sui_api_url: str, owner: str, account: str, contract_address: str) -> List[Dict[str, str]]:
     """
     Asynchronously form triples that contain the "coin", "type", and "program_id" values from the collateral objects.
     """
     triples = []
-    collateral_objects = await get_collateral_objects(session, network, owner, account, contract_address)
+    collateral_objects = await get_collateral_objects(session, sui_api_url, owner, account, contract_address)
     for obj in collateral_objects:
         data = obj['data']
         triple = {
@@ -65,17 +89,29 @@ async def form_coin_type_prgm_triples(session: aiohttp.ClientSession, network: s
         }
         triples.append(triple)
     return triples
+    
 
-async def get_program_objects(session: aiohttp.ClientSession, network: str, program_ids: List[str]) -> List[Dict[str, Any]]:
+async def get_objects(session: aiohttp.ClientSession, sui_api_url: str, addresses: List[str]) -> List[Dict[str, Any]]:
     """
-    Asynchronously retrieve program objects from the chain.
+    Get multiple objects using sui_multiGetObjects.
+    
+    Args:
+        session: The aiohttp client session
+        sui_api_url: The API URL to query
+        addresses: List of object addresses
+    
+    Returns:
+        List[Dict[str, Any]]: List of objects
     """
+    if not addresses:
+        return []
+    
     request = {
         "jsonrpc": "2.0",
         "id": 1,
         "method": "sui_multiGetObjects",
         "params": [
-            program_ids,
+            addresses,
             {
                 "showType": True,
                 "showOwner": True,
@@ -88,9 +124,13 @@ async def get_program_objects(session: aiohttp.ClientSession, network: str, prog
         ]
     }
 
-    async with session.post(f'https://fullnode.{network}.sui.io:443', json=request) as response:
-        result = await response.json()
-        return result['result']
+    try:
+        async with session.post(sui_api_url, json=request) as response:
+            result = await response.json()
+            return result.get('result', [])
+    except Exception as e:
+        raise ValueError(f"Error getting objects: {str(e)}")
+
 
 def convert_feed_bytes_to_hex_str(feed_bytes: List[int]) -> str:
     """
@@ -101,15 +141,17 @@ def convert_feed_bytes_to_hex_str(feed_bytes: List[int]) -> str:
         feed_hex_str += f"{byte:02x}"
     return feed_hex_str
 
-async def get_price_feed(session: aiohttp.ClientSession, feed_id: str) -> Dict[str, Any]:
+
+async def get_price_feed(session: aiohttp.ClientSession, feed_id: str, pyth_url: str) -> Dict[str, Any]:
     """
     Asynchronously get price feed updates from Pyth API.
     """
     query_args = f"ids%5B%5D={feed_id}"
     
-    async with session.get(f'https://hermes.pyth.network/v2/updates/price/latest?{query_args}') as response:
+    async with session.get(pyth_url + query_args) as response:
         result = await response.json()
         return result['parsed'][0]
+
 
 def join_collaterals(dict_list1: List[Dict[str, Any]], dict_list2: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
@@ -126,12 +168,30 @@ def join_collaterals(dict_list1: List[Dict[str, Any]], dict_list2: List[Dict[str
     
     return joined_list
 
-async def calc_total_account_value(network: str, owner: str, account: str, contract_address: str) -> float:
+
+async def calc_total_account_value(owner: str, account: str, contract_address: str) -> float:
     """
     Asynchronously calculate the total account value.
+    
+    Args:
+        owner (str): Owner address
+        account (str): Account ID
+        contract_address (str): Contract address
+    
+    Returns:
+        float: The total account value
     """
+
+    config = load_config()
+    sui_api_url = config["sui_api_url"]
+    contract_address = config["contract_address"]
+    pyth_url = config["pyth_price_feed_url"]
+        
+    if not sui_api_url or not contract_address:
+        raise ValueError("SUI API URL or Contract Address not specified in config or parameters")
+    
     async with aiohttp.ClientSession() as session:
-        collateral_triples = await form_coin_type_prgm_triples(session, network, owner, account, contract_address)
+        collateral_triples = await form_coin_type_prgm_triples(session, sui_api_url, owner, account, contract_address)
         
         account_value = 0
         suppported_collateral_list = []
@@ -142,7 +202,7 @@ async def calc_total_account_value(network: str, owner: str, account: str, contr
                 continue
             programs_retreieved[triple['program_id']] = True
             
-        programs = await get_program_objects(session, network, list(programs_retreieved.keys()))
+        programs = await get_objects(session, sui_api_url, list(programs_retreieved.keys()))
         
         for program in programs:
             suppported_collateral_list += program['data']['content']['fields']['supported_collateral']
@@ -153,7 +213,7 @@ async def calc_total_account_value(network: str, owner: str, account: str, contr
         price_feed_tasks = []
         for item in joined_list:
             feed_id = convert_feed_bytes_to_hex_str(item['price_feed_id_bytes'])
-            price_feed_tasks.append(get_price_feed(session, feed_id))
+            price_feed_tasks.append(get_price_feed(session, feed_id, pyth_url))
         
         # Execute all price feed requests concurrently
         price_feed_results = await asyncio.gather(*price_feed_tasks)
@@ -163,3 +223,193 @@ async def calc_total_account_value(network: str, owner: str, account: str, contr
             account_value += int(item['coin']) * int(feed_data['price']['price']) * pow(10, (-1 * item['token_decimals']) + feed_data['price']['expo'])
             
         return account_value
+
+
+def filter_vault_objects(owned_objects: List[Dict]) -> List[Dict]:
+    """
+    Filter the list of owned objects to return only the vault objects.
+    
+    A vault object has a type matching the pattern: *::lp::Vault<*>
+    
+    Args:
+        owned_objects: List of objects owned by a contract
+        
+    Returns:
+        List of vault objects
+    """
+    vault_objects = []
+    
+    for obj in owned_objects:
+        try:
+            obj_type = obj.get('data', {}).get('type', '')
+            # Check if the object type matches the vault pattern
+            if '::lp::Vault<' in obj_type:
+                vault_objects.append(obj)
+        except Exception as e:
+            raise ValueError(f"Error processing object: {str(e)}")
+            
+    return vault_objects
+
+
+async def parse_vault_token_type(token_type: str) -> str:
+    """
+    Parse the vault token type string to extract relevant information.
+    Example: 0x...::lp::Vault<0x...::test_coin::TEST_COIN, 0x...::test_coin::TEST_COIN>
+    
+    Returns:
+        Dict containing parsed information including:
+        - raw_type: original type string
+        - package_id: the package ID (part before ::lp::Vault)
+        - token_types: list of token types within the angle brackets
+        - coin_type: the first token type (the coin that the vault holds)
+    """
+    
+    # Extract content inside angle brackets
+    angle_content = token_type.split("<")[1].split(">")[0]
+    coin_type = angle_content.split(",")[0].strip()
+        
+    # Also keep the full list of token types for backward compatibility
+    #token_types = [t.strip() for t in angle_content.split(",")]
+    #result["token_types"] = token_types
+    
+    return coin_type
+    
+
+async def calc_total_vault_values() -> Dict:
+    """
+    Calculate the total value locked across all vaults defined in the config.
+        
+    Returns:
+        Dict: Dictionary containing vault value information
+    """
+    # Load config once at the beginning
+    config = load_config()
+    sui_api_url = config.get("sui_api_url", None)
+    vault_addresses = config.get("vault_addresses", None)
+    global_address = config.get("contract_global", None)
+    pyth_url = config.get("pyth_price_feed_url", None)
+    
+    if not sui_api_url or not vault_addresses or not global_address:
+        raise ValueError("Error loading config: One or more fields are missing")
+    
+    async with aiohttp.ClientSession() as session:
+        # Get all vault objects using multiGetObjects
+        vault_objects = await get_objects(session, sui_api_url, vault_addresses)
+        global_object = await get_objects(session, sui_api_url, [global_address])
+        if not global_object:
+            raise ValueError("Could not retrieve global object")
+        
+        # Extract supported LP tokens and price feed bytes from global object
+        global_data = global_object[0]['data']['content']['fields']
+        #print(f"\n\nGLOBAL DATA:\n {global_data}\n")
+        supported_lp = global_data.get('supported_lp', [])
+        price_feed_bytes = global_data.get('price_feed_bytes', [])
+        
+        if not supported_lp or not price_feed_bytes:
+            raise ValueError("Global object missing supported_lp or price_feed_bytes")
+        
+        # Create a mapping of coin type to its index in the supported_lp list
+        coin_type_to_index = {}
+        for i, lp_entry in enumerate(supported_lp):
+            #print(i, lp_entry)
+            coin_type_to_index[f"0x{lp_entry}"] = i
+        #print(f"\nCoin type to index mapping: {coin_type_to_index}\n")
+        
+        cumulative_vault_total = 0.0
+        vault_details = []
+        
+        # Create price feed fetch tasks for concurrent execution
+        price_feed_tasks = []
+        vault_coin_types = []
+        
+        # Process each vault object to prepare price feed requests
+        for vault in vault_objects:
+            try:
+                vault_data = vault.get('data', {})
+                #print(vault_data)
+                vault_type = vault_data.get('type', '') # needs changing
+                content = vault_data.get('content', {})
+                fields = content.get('fields', {})
+                #print(f"\n\nFIELDS:\n {fields}\n")
+                
+                # Get the vault's balance/amount
+                coin = float(fields.get('coin', 0))
+                if coin == 0:
+                    #print(f"No coin balance found for vault: {vault_data.get('objectId', '')}")
+                    continue
+                
+                # Parse token type to extract underlying asset information
+                coin_type = await parse_vault_token_type(vault_type)
+                #print(f"\nCOIN_TYPE: {coin_type}\n")
+                
+                # Find the index of this coin type in the supported_lp list
+                if coin_type in coin_type_to_index:
+                    index = coin_type_to_index[coin_type]
+                    if index < len(price_feed_bytes):
+                        # Get the corresponding price feed bytes
+                        feed_bytes = price_feed_bytes[index]
+                        
+                        # Convert feed bytes to hex string for Pyth API
+                        feed_id = convert_feed_bytes_to_hex_str(feed_bytes)
+                        
+                        # Add to list of tasks
+                        price_feed_tasks.append(get_price_feed(session, feed_id, pyth_url))
+                        vault_coin_types.append({
+                            "id": vault_data.get('objectId', ''),
+                            "type": vault_type,
+                            "coin": coin,
+                            "coin_type": coin_type,
+                            "feed_id": feed_id
+                        })
+                else:
+                    raise ValueError(f"Coin type not found in supported_lp: {coin_type}")
+            except Exception as e:
+                raise ValueError(f"Error processing vault object: {str(e)}")
+        
+        # Execute all price feed requests concurrently
+        if price_feed_tasks:
+            price_feed_results = await asyncio.gather(*price_feed_tasks, return_exceptions=True)
+            
+            # Calculate values using price feed results
+            for i, (vault_info, price_result) in enumerate(zip(vault_coin_types, price_feed_results)):
+                try:
+                    if not isinstance(price_result, Exception):
+                        # Get token info from global object based on coin type
+                        coin_type = vault_info['coin_type']
+                        #print(f"Processing vault for coin type: {coin_type}\n")
+                        #print(f'price_result: {price_result}\n')
+                        index = coin_type_to_index.get(coin_type)
+                        
+                        if index is not None and index < len(supported_lp):                            
+                            # Calculate value based on price feed data
+                            if isinstance(price_result, dict):
+                                price = price_result.get('price', {}).get('price', 0)
+                                expo = price_result.get('price', {}).get('expo', 0)
+                                
+                                # Apply decimal conversion based on token decimals and price expo
+                                value = vault_info['coin'] * int(price) * pow(10, expo)
+                            else:
+                                raise Exception(f"Invalid price result format for {vault_info['coin_type']}")
+                            
+                            # Add to total and details
+                            cumulative_vault_total += value
+                            
+                            vault_detail = {
+                                #"id": vault_info['id'],
+                                "type": vault_info['type'],
+                                "coin": vault_info['coin'],
+                                "coin_type": vault_info['coin_type'],
+                                "value": value
+                            }
+                            
+                            vault_details.append(vault_detail)
+                    else:
+                        raise Exception(f"Failed to fetch price for {vault_info['coin_type']}: {str(price_result)}")
+                except Exception as e:
+                    print(f"Error calculating vault value: {str(e)}")
+        
+        return {
+            "totalValueLocked": cumulative_vault_total,
+            "vaults": vault_details,
+            "count": len(vault_details)
+        }

--- a/backend/config/backend_config.json
+++ b/backend/config/backend_config.json
@@ -1,0 +1,9 @@
+{
+  "contract_address": "0xaf05e950da30954a3c13a93d122390ecf8db1d26ff1de9ab6ada403f78bc84b4",
+  "contract_global": "0xf1905820b04efdc3b4284482304bb5091567359a91ae72402a1d038a6d36ab54",
+  "pyth_price_feed_url": "https://hermes.pyth.network/v2/updates/price/latest?",
+  "sui_api_url": "https://fullnode.testnet.sui.io:443",
+  "vault_addresses": [
+    "0x815436a2eac2aa5e7dcb93c8c61df0c21c19afb9569f5f2128d85773525510bd"
+  ]
+}

--- a/backend/server.py
+++ b/backend/server.py
@@ -4,7 +4,10 @@ import asyncio
 import concurrent.futures
 from functools import wraps
 
-from async_backend import calc_total_account_value
+from async_backend import (
+    calc_total_account_value,
+    calc_total_vault_values
+)
 
 app = Flask(__name__)
 CORS(app)
@@ -41,14 +44,30 @@ async def calculate_total_account_value():
         contract = data.get('contract')
         
         # Use the async version of the calculation function
-        total_value = await calc_total_account_value(network, address, account, contract)
+        total_value = await calc_total_account_value(address, account, contract)
         
         return jsonify({"totalValue": total_value}), 200
     
     except Exception as e:
         print(f"Error calculating total account value: {str(e)}")
         return jsonify({"error": f"Failed to calculate total account value: {str(e)}"}), 500
+    
 
+@app.route('/api/calculateTotalValueLocked', methods=['POST'])
+@async_route
+async def calculate_total_value_locked():
+    try:
+        # Calculate total value locked using config-based vault addresses
+        result = await calc_total_vault_values()
+        
+        return jsonify(result), 200
+    
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        print(f"Error calculating total value locked: {str(e)}")
+        return jsonify({"error": f"Failed to calculate total value locked: {str(e)}"}), 500
+    
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/backend/test_vault_values.py
+++ b/backend/test_vault_values.py
@@ -1,0 +1,15 @@
+import asyncio
+from async_backend import calc_total_vault_values, load_config
+
+async def test():
+    # Load config to show available settings
+    config = load_config()
+    print(f"Using config: SUI_API_URL={config['sui_api_url']}, Contract={config['contract_address']}")
+    print(f"Vault addresses: {len(config['vault_addresses'])}")
+    
+    # Call without specifying network (will use config's network)
+    result = await calc_total_vault_values()
+    print(f"Total vault values: {result}")
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/backend/tests/mock_data.json
+++ b/backend/tests/mock_data.json
@@ -6,35 +6,29 @@
       "data": [
         {
           "data": {
-            "objectId": "0xsample_object_id",
+            "objectId": "0xsample_collateral_id",
             "version": "1",
-            "digest": "sample_digest",
-            "type": "0xsample_contract::collateral::Collateral<0xsample_contract::test_coin::TEST_COIN>",
+            "digest": "0xsample_digest",
+            "type": "0xsample_contract::collateral::Collateral<0xsample_coin::sample::SAMPLE_COIN>",
             "content": {
               "fields": {
                 "account_id": "0xsample_account",
                 "coin": "100",
-                "program_id": "0xsample_program_id",
-                "id": {
-                  "id": "0xsample_id"
-                },
-                "collateral_index": "0"
-              },
-              "type": "0xsample_contract::collateral::Collateral<0xsample_contract::test_coin::TEST_COIN>"
+                "program_id": "0xsample_program_id"
+              }
             }
           }
         },
         {
           "data": {
-            "objectId": "0xnon_collateral_object",
+            "objectId": "0xother_id",
             "version": "1",
-            "digest": "sample_digest",
-            "type": "0xsample_contract::other_type::Other",
+            "digest": "0xother_digest",
+            "type": "0xsample_contract::other::Object",
             "content": {
               "fields": {
-                "value": "200"
-              },
-              "type": "0xsample_contract::other_type::Other"
+                "data": "some data"
+              }
             }
           }
         }
@@ -45,28 +39,23 @@
   },
   "collateral_object": {
     "data": {
-      "objectId": "0xsample_object_id",
+      "objectId": "0xsample_collateral_id",
       "version": "1",
-      "digest": "sample_digest",
-      "type": "0xsample_contract::collateral::Collateral<0xsample_contract::test_coin::TEST_COIN>",
+      "digest": "0xsample_digest",
+      "type": "0xsample_contract::collateral::Collateral<0xsample_coin::sample::SAMPLE_COIN>",
       "content": {
         "fields": {
           "account_id": "0xsample_account",
           "coin": "100",
-          "program_id": "0xsample_program_id",
-          "id": {
-            "id": "0xsample_id"
-          },
-          "collateral_index": "0"
-        },
-        "type": "0xsample_contract::collateral::Collateral<0xsample_contract::test_coin::TEST_COIN>"
+          "program_id": "0xsample_program_id"
+        }
       }
     }
   },
   "collateral_triples": [
     {
       "coin": "100",
-      "type": "0xsample_contract::collateral::Collateral<0xsample_contract::test_coin::TEST_COIN>",
+      "type": "0xsample_contract::collateral::Collateral<0xsample_coin::sample::SAMPLE_COIN>",
       "program_id": "0xsample_program_id"
     }
   ],
@@ -75,29 +64,19 @@
       "data": {
         "objectId": "0xsample_program_id",
         "version": "1",
-        "digest": "sample_digest",
+        "digest": "0xprogram_digest",
         "type": "0xsample_contract::programs::Program",
-        "owner": {
-          "Shared": {
-            "initial_shared_version": "1"
-          }
-        },
         "content": {
           "fields": {
-            "id": {
-              "id": "0xsample_program_id_inner"
-            },
             "supported_collateral": [
               {
-                "type": "0xsample_contract::programs::CollateralIdentifier",
                 "fields": {
-                  "price_feed_id_bytes": [35, 215, 49, 81, 19, 245, 177, 211, 186, 122, 131, 96, 76, 68, 185, 77, 121, 244, 253, 105, 175, 119, 248, 4, 252, 127, 146, 10, 109, 198, 87, 68],
-                  "token_decimals": 10,
-                  "token_info": "sample_contract::test_coin::TEST_COIN"
+                  "token_info": "sample_coin::sample::SAMPLE_COIN",
+                  "token_decimals": 8,
+                  "price_feed_id_bytes": [1, 2, 3, 4]
                 }
               }
-            ],
-            "shared_price_decimals": 8
+            ]
           }
         }
       }
@@ -116,23 +95,67 @@
   "price_feed_response": {
     "parsed": [
       {
-        "id": "0xsample_price_id",
+        "id": "0xsample_feed_id",
         "price": {
-          "price": "150000000",
-          "conf": "1250000",
+          "price": "10000000",
+          "conf": "123456",
           "expo": -8,
-          "publish_time": 1685447858
-        },
-        "ema_price": {
-          "price": "149500000",
-          "conf": "1300000",
-          "expo": -8,
-          "publish_time": 1685447858
+          "publishTime": 1651651651
         }
       }
     ],
     "raw": [
       "sample_raw_data"
     ]
+  },
+  "vault_objects": [
+    {
+      "data": {
+        "objectId": "0xvault1",
+        "version": "1",
+        "digest": "0xvault1_digest",
+        "type": "0xpackage::lp::Vault<0xpackage::coin::COIN, 0xpackage::coin::COIN>",
+        "content": {
+          "fields": {
+            "coin": "1000",
+            "balance": "1000"
+          }
+        }
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xvault2",
+        "version": "1",
+        "digest": "0xvault2_digest",
+        "type": "0xpackage::lp::Vault<0xpackage::token::TOKEN, 0xpackage::token::TOKEN>",
+        "content": {
+          "fields": {
+            "coin": "500",
+            "balance": "500"
+          }
+        }
+      }
+    }
+  ],
+  "global_object": {
+    "data": {
+      "objectId": "0xglobal_address",
+      "version": "1",
+      "digest": "0xglobal_digest",
+      "type": "0xpackage::global::Global",
+      "content": {
+        "fields": {
+          "supported_lp": [
+            "package::coin::COIN",
+            "package::token::TOKEN"
+          ],
+          "price_feed_bytes": [
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            [9, 10, 11, 12, 13, 14, 15, 16]
+          ]
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- Adds a new endpoint to return the value for each vault, as well as a cumulative value across all vaults.
- Updates/Adds tests, all of which pass locally.
- Created a config json file for the backend

- Addresses [PP-22] for configurable backend fields