### PR TITLE
[PP-95] Query LP Balance

### DIFF
--- a/backend/config/backend_config.json
+++ b/backend/config/backend_config.json
@@ -3,8 +3,16 @@
   "contract_global": "0xf1905820b04efdc3b4284482304bb5091567359a91ae72402a1d038a6d36ab54",
   "pyth_price_feed_url": "https://hermes.pyth.network/v2/updates/price/latest?",
   "sui_api_url": "https://fullnode.testnet.sui.io:443",
-  "vault_addresses": [
-    "0x815436a2eac2aa5e7dcb93c8c61df0c21c19afb9569f5f2128d85773525510bd",
-    "0xd21a7b73ca05b287f3ec46cd1a6b3ddfa0231796b6f1e724b6ab0717b3d1940a"
+  "vaults": [
+    {
+      "vault_address": "0x815436a2eac2aa5e7dcb93c8c61df0c21c19afb9569f5f2128d85773525510bd",
+      "coin_type": "0xaf05e950da30954a3c13a93d122390ecf8db1d26ff1de9ab6ada403f78bc84b4::test_coin::TEST_COIN",
+      "lp_type": "0x2::coin::Coin<0xaf05e950da30954a3c13a93d122390ecf8db1d26ff1de9ab6ada403f78bc84b4::lp::LPToken<0xaf05e950da30954a3c13a93d122390ecf8db1d26ff1de9ab6ada403f78bc84b4::test_coin::TEST_COIN>>"
+    },
+    {
+      "vault_address": "0xd21a7b73ca05b287f3ec46cd1a6b3ddfa0231796b6f1e724b6ab0717b3d1940a",
+      "coin_type": "0xf38326e8cfe02507ba7b47bcf33f476ca4a98b57911b0a023f4f4dbe7add2b8d::ANOTHER_TEST_COIN::ANOTHER_TEST_COIN",
+      "lp_type": "0xf38326e8cfe02507ba7b47bcf33f476ca4a98b57911b0a023f4f4dbe7add2b8d::ANOTHER_LP_COIN::ANOTHER_LP_COIN"
+    }
   ]
 }

--- a/backend/server.py
+++ b/backend/server.py
@@ -6,7 +6,8 @@ from functools import wraps
 
 from async_backend import (
     calc_total_account_value,
-    calc_total_vault_values
+    calc_total_vault_values,
+    get_lp_balance
 )
 
 app = Flask(__name__)
@@ -67,6 +68,26 @@ async def calculate_total_value_locked():
     except Exception as e:
         print(f"Error calculating total value locked: {str(e)}")
         return jsonify({"error": f"Failed to calculate total value locked: {str(e)}"}), 500
+    
+
+@app.route('/api/lpBalance', methods=['POST'])
+@async_route
+async def lp_balance():
+    try:
+        data = request.get_json()
+        if data is None:
+            return jsonify({"error": "Invalid JSON data"}), 400
+        owner = data.get('owner')
+        vault_id = data.get('vault_id')
+        if not owner or not vault_id:
+            return jsonify({"error": "Missing required parameters: owner and vault_id"}), 400
+        balance = await get_lp_balance(owner, vault_id)
+        return jsonify({"lpBalance": balance}), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        print(f"Error retrieving LP balance: {str(e)}")
+        return jsonify({"error": f"Failed to retrieve LP balance: {str(e)}"}), 500
     
 
 if __name__ == "__main__":

--- a/backend/test_lp_balance.py
+++ b/backend/test_lp_balance.py
@@ -1,0 +1,11 @@
+import asyncio
+from async_backend import get_lp_balance
+
+async def test():
+    owner = "0xab8d1b5a5311c9400e3eaf5c3b641f10fb48b43cc30d365fa8a98a6ca6bd4865"
+    vault_id = "0x815436a2eac2aa5e7dcb93c8c61df0c21c19afb9569f5f2128d85773525510bd"
+    balance = await get_lp_balance(owner, vault_id)
+    print(f"LP balance for owner {owner} in vault {vault_id}: {balance}")
+
+if __name__ == "__main__":
+    asyncio.run(test())


### PR DESCRIPTION
- Addresses PP-80, switching print statements to use Python's logging module
- Added logic for calculating the LP balance of a specific owner for a specific vault
- Updated get_owned_objects to handle pagination
- Added a fallback if backend config env variable is not found