### PR TITLE
[PP-114] Display Real Position Data

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pismo-frontend",
-  "version": "1.6.5",
+  "version": "1.7.5",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/frontend/src/components/trading/CurrentPositions.tsx
+++ b/frontend/src/components/trading/CurrentPositions.tsx
@@ -1,31 +1,58 @@
-import React, { useState } from 'react';
-// Assuming Icons.tsx exists and exports necessary icons like TokenIcon
-// import { TokenIcon } from './Icons'; 
+import React, { useState, useEffect, useRef } from 'react';
+import { PositionData } from '@/types';
+import { pythPriceFeedService } from '@/utils/pythPriceFeed'; // Import the service
 
-interface Position {
-    id: string;
-    token: string;
-    type: 'Long' | 'Short';
-    value: string; // e.g., "$1,234.56"
-    leverage: number; // e.g., 10 (for 10x)
-    amount: string; // e.g., "1.5 ETH"
-}
+// Hardcoded Account ID for now
+const ACCOUNT_ID = "0xab8d1b5a5311c9400e3eaf5c3b641f10fb48b43cc30d365fa8a98a6ca6bd4865";
+const INDEXER_URL = process.env.INDEXER_URL || "http://localhost:3001"; // Fallback for safety
 
-// Mock Data
-const mockPositions: Position[] = [
-    { id: '1', token: 'ETH', type: 'Long', value: '$5,432.10', leverage: 10, amount: '2.8 ETH' },
-    { id: '2', token: 'BTC', type: 'Short', value: '$10,876.50', leverage: 5, amount: '0.5 BTC' },
-];
-
-// --- Helper Functions (Basic Parsing) ---
+// --- Helper Functions ---
 const parseAmountString = (amountStr: string): number => {
-    const match = amountStr.match(/^[+-]?([0-9]*[.])?[0-9]+/);
-    return match ? parseFloat(match[0]) : 0;
+    // Allow parsing potentially negative inputs during validation, but clamp later
+    return parseFloat(amountStr) || 0;
 };
 
-const parseValueString = (valueStr: string): number => {
-    const cleaned = valueStr.replace(/[$,]/g, '');
-    return parseFloat(cleaned) || 0;
+const formatCurrency = (value: number | null | undefined): string => {
+    if (value === null || value === undefined || isNaN(value)) {
+        return "$ --";
+    }
+    return value.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+};
+
+const formatAmount = (amountStr: string | undefined | null, decimals: number): string => {
+    if (!amountStr) return "0.00";
+    try {
+        const amount = parseFloat(amountStr);
+        const value = amount / (10 ** decimals);
+        // Adjust formatting as needed, e.g., minimum/maximum fraction digits
+        return value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: decimals });
+    } catch (e) {
+        console.error("Error formatting amount:", e);
+        return "Error";
+    }
+};
+
+const calculatePositionValue = (position: PositionData, livePrice: number | undefined): number | null => {
+    // Assume amount_decimals is 6 as per user request
+    const amountDecimals = 6; // Use a constant for clarity
+
+    if (livePrice === undefined || !position.amount) {
+        return null;
+    }
+    try {
+        // Use the correctly calculated decimal amount
+        const amount = parseFloat(position.amount) / (10 ** amountDecimals);
+        const value = amount * livePrice;
+        return value;
+    } catch (e) {
+        console.error("Error calculating position value:", e);
+        return null;
+    }
 };
 
 // --- Slider Component ---
@@ -44,24 +71,139 @@ const Slider: React.FC<{ value: number; onChange: (value: number) => void; min?:
 };
 
 const CurrentPositions: React.FC = () => {
+    const [positions, setPositions] = useState<PositionData[]>([]);
+    const [livePrices, setLivePrices] = useState<Record<string, number | undefined>>({}); // Allow undefined for loading state
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
     const [closingPositionId, setClosingPositionId] = useState<string | null>(null);
     const [modalCloseAmount, setModalCloseAmount] = useState<string>("");
     const [closePercentage, setClosePercentage] = useState<number>(100);
+    const [modalAmountError, setModalAmountError] = useState<string | null>(null); // State for modal input error
+    const subscribedFeedIdsRef = useRef<Set<string>>(new Set());
 
-    const positionToClose = closingPositionId ? mockPositions.find(p => p.id === closingPositionId) : null;
-    const totalPositionAmount = positionToClose ? parseAmountString(positionToClose.amount) : 0;
-    const totalPositionValue = positionToClose ? parseValueString(positionToClose.value) : 0;
+    // Define decimals constant, assuming 6 based on previous context
+    const AMOUNT_DECIMALS = 6;
+
+    useEffect(() => {
+        const fetchPositions = async () => {
+            setIsLoading(true);
+            setError(null);
+            try {
+                const response = await fetch(`${INDEXER_URL}/v0/${ACCOUNT_ID}/positions`);
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                const data: PositionData[] = await response.json();
+                setPositions(data);
+            } catch (err) {
+                console.error("Failed to fetch positions:", err);
+                setError(err instanceof Error ? err.message : "An unknown error occurred");
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchPositions();
+    }, []);
+
+    useEffect(() => {
+        const requiredFeedIds = new Set(positions.map(p => {
+            const feedId = p.price_feed_id_bytes;
+            return feedId.startsWith('0x') ? feedId : `0x${feedId}`;
+        }).filter(id => id && id !== '0x'));
+
+        console.log("[CurrentPositions] Required Feed IDs:", Array.from(requiredFeedIds));
+        const currentSubscribedIds = subscribedFeedIdsRef.current;
+
+        requiredFeedIds.forEach(feedId => {
+            if (!currentSubscribedIds.has(feedId)) {
+                console.log(`[CurrentPositions] Subscribing to Pyth feed: ${feedId}`);
+                setLivePrices(prev => ({ ...prev, [feedId]: prev[feedId] ?? undefined }));
+                pythPriceFeedService.subscribe(feedId, (price) => {
+                    if (requiredFeedIds.has(feedId)) {
+                        setLivePrices(prevPrices => ({
+                            ...prevPrices,
+                            [feedId]: price
+                        }));
+                    }
+                }).then(subscribed => {
+                    if (subscribed) {
+                        currentSubscribedIds.add(feedId);
+                        pythPriceFeedService.getLatestPrice(feedId).then(initialData => {
+                            if (initialData && requiredFeedIds.has(feedId)) {
+                                setLivePrices(prevPrices => ({
+                                    ...prevPrices,
+                                    [feedId]: initialData.price
+                                }));
+                            } else if (!initialData) {
+                                console.warn(`[CurrentPositions] Failed to get initial price for ${feedId}`);
+                            }
+                        }).catch(err => {
+                            console.error(`[CurrentPositions] Error fetching initial price for ${feedId}:`, err);
+                        });
+                    } else {
+                        if (!livePrices[feedId]) {
+                            pythPriceFeedService.getLatestPrice(feedId).then(initialData => {
+                                if (initialData && requiredFeedIds.has(feedId)) {
+                                    setLivePrices(prevPrices => ({ ...prevPrices, [feedId]: initialData.price }));
+                                }
+                            });
+                        }
+                    }
+                }).catch(err => {
+                    console.error(`[CurrentPositions] Error during subscription process for ${feedId}:`, err);
+                });
+            }
+        });
+
+        currentSubscribedIds.forEach(feedId => {
+            if (!requiredFeedIds.has(feedId)) {
+                console.log(`[CurrentPositions] Unsubscribing from no longer required feed: ${feedId}`);
+                pythPriceFeedService.unsubscribe(feedId);
+                currentSubscribedIds.delete(feedId);
+                setLivePrices(prev => {
+                    const newState = { ...prev };
+                    delete newState[feedId];
+                    return newState;
+                });
+            }
+        });
+
+        subscribedFeedIdsRef.current = new Set(currentSubscribedIds);
+
+        return () => {
+            console.log("[CurrentPositions] Component unmounting. Cleaning up subscriptions for IDs:", Array.from(subscribedFeedIdsRef.current));
+            subscribedFeedIdsRef.current.forEach(feedId => {
+                pythPriceFeedService.unsubscribe(feedId);
+            });
+            subscribedFeedIdsRef.current.clear();
+        };
+    }, [positions]);
+
+    const positionToClose = closingPositionId ? positions.find(p => p.position_id === closingPositionId) : null;
+    // Calculate total position amount considering decimals
+    const totalPositionAmount = positionToClose ? (parseFloat(positionToClose.amount) / (10 ** AMOUNT_DECIMALS)) : 0;
+
+    // Calculate the current total value of the position being closed
+    const positionToCloseLivePrice = positionToClose ? livePrices[positionToClose.price_feed_id_bytes.startsWith('0x') ? positionToClose.price_feed_id_bytes : `0x${positionToClose.price_feed_id_bytes}`] : undefined;
+    const positionToCloseLiveValue = positionToClose ? calculatePositionValue(positionToClose, positionToCloseLivePrice) : null;
+
+    // Calculate the value of the portion being closed
+    const closingValue = positionToCloseLiveValue !== null ? positionToCloseLiveValue * (closePercentage / 100) : null;
 
     const openModal = (positionId: string) => {
-        const position = mockPositions.find(p => p.id === positionId);
+        const position = positions.find(p => p.position_id === positionId);
         if (!position) return;
-        const fullAmount = parseAmountString(position.amount);
-        
+        // Calculate the full amount considering decimals for display
+        const fullAmountDecimal = parseFloat(position.amount) / (10 ** AMOUNT_DECIMALS);
+
         setClosingPositionId(positionId);
         setClosePercentage(100);
-        setModalCloseAmount(fullAmount.toString());
+        // Set the initial modal amount to the full decimal value, formatted
+        setModalCloseAmount(fullAmountDecimal.toFixed(AMOUNT_DECIMALS));
         setIsModalOpen(true);
+        setModalAmountError(null); // Reset error on open
     };
 
     const closeModal = () => {
@@ -69,136 +211,203 @@ const CurrentPositions: React.FC = () => {
         setClosingPositionId(null);
         setModalCloseAmount("");
         setClosePercentage(100);
+        setModalAmountError(null); // Reset error on close
     };
 
     const handleModalAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const inputAmountStr = e.target.value;
         setModalCloseAmount(inputAmountStr);
+        setModalAmountError(null); // Clear error initially
+
+        // Allow only numbers and a single decimal point
+        if (inputAmountStr && !/^-?\d*\.?\d*$/.test(inputAmountStr)) {
+             setModalAmountError("Please enter a valid number.");
+             setClosePercentage(0); // Reset percentage if input is invalid
+             return;
+        }
 
         const inputAmountNum = parseFloat(inputAmountStr);
-        if (!isNaN(inputAmountNum) && totalPositionAmount > 0) {
-            const percentage = Math.max(0, Math.min(100, (inputAmountNum / totalPositionAmount) * 100));
-            setClosePercentage(percentage);
-        } else if (inputAmountStr === "") {
+
+        // Check for NaN explicitly after regex allows partial inputs like "." or "-"
+        if (isNaN(inputAmountNum) && inputAmountStr !== "" && inputAmountStr !== "." && inputAmountStr !== "-") {
+            setModalAmountError("Please enter a valid number.");
             setClosePercentage(0);
+            return;
+        }
+
+        if (!isNaN(inputAmountNum)) {
+             // Prevent negative numbers
+            if (inputAmountNum < 0) {
+                setModalAmountError("Amount cannot be negative.");
+                setClosePercentage(0); // Reset percentage for negative input
+            } else if (inputAmountNum > totalPositionAmount) {
+                // Check if input exceeds total position amount
+                setModalAmountError("Amount cannot exceed position size.");
+                setClosePercentage(100); // Set percentage to 100 if input exceeds max
+                // Optionally, cap the input value to the max
+                // setModalCloseAmount(totalPositionAmount.toFixed(AMOUNT_DECIMALS));
+            } else if (totalPositionAmount > 0) {
+                const percentage = Math.max(0, Math.min(100, (inputAmountNum / totalPositionAmount) * 100));
+                setClosePercentage(percentage);
+            } else {
+                setClosePercentage(0); // Handle case where totalPositionAmount is 0
+            }
+        } else if (inputAmountStr === "") {
+            setClosePercentage(0); // Set percentage to 0 if input is empty
         }
     };
-    
+
     const handleSliderChange = (percentage: number) => {
         setClosePercentage(percentage);
+        setModalAmountError(null); // Clear error when slider is used
+
         if (totalPositionAmount > 0) {
             const calculatedAmount = (totalPositionAmount * percentage) / 100;
-            const formattedAmount = calculatedAmount.toFixed(Math.min(8, Math.max(2, (calculatedAmount.toString().split('.')[1] || '').length))); 
+            // Format with the correct number of decimals
+            const formattedAmount = calculatedAmount.toFixed(AMOUNT_DECIMALS);
             setModalCloseAmount(formattedAmount);
         } else {
-            setModalCloseAmount("0");
+            setModalCloseAmount("0"); // Or "0.000000" if preferred
         }
     };
 
     const handleConfirmClose = () => {
-        console.log(`Closing position ${closingPositionId} with amount ${modalCloseAmount} (${closePercentage.toFixed(0)}%)`);
-        closeModal(); 
-    };
+        // Convert the decimal amount back to the base unit integer for the transaction
+        const closeAmountBaseUnits = Math.round(parseFloat(modalCloseAmount) * (10 ** AMOUNT_DECIMALS));
 
-    const valueToClose = (totalPositionValue * closePercentage) / 100;
+        // Ensure the calculated base units are not negative and not zero if modalCloseAmount was > 0
+        if (isNaN(closeAmountBaseUnits) || closeAmountBaseUnits < 0 || (parseFloat(modalCloseAmount) > 0 && closeAmountBaseUnits === 0)) {
+             console.error("Invalid amount calculated for closing:", modalCloseAmount, closeAmountBaseUnits);
+             setModalAmountError("Invalid closing amount calculated.");
+             return; // Prevent closing with invalid amount
+        }
+
+        console.log(`Closing position ${closingPositionId} with amount ${modalCloseAmount} (${closePercentage.toFixed(0)}%) - Base Units: ${closeAmountBaseUnits}`);
+        // TODO: Implement actual transaction submission using closeAmountBaseUnits
+        closeModal();
+    };
 
     return (
         <section className="mt-8">
             <h2 className="text-xl font-semibold text-primaryText mb-4 pl-4">Your Positions</h2>
             <div className="space-y-4">
-                {mockPositions.length === 0 ? (
+                {isLoading ? (
+                    <p className="text-secondaryText text-center py-4">Loading positions...</p>
+                ) : error ? (
+                    <p className="text-red-500 text-center py-4">Error loading positions: {error}</p>
+                ) : positions.length === 0 ? (
                     <p className="text-secondaryText text-center py-4">You have no open positions.</p>
                 ) : (
-                    mockPositions.map((position) => (
-                        <div key={position.id} className="card bg-backgroundOffset p-4 rounded-lg flex flex-col sm:flex-row sm:items-center justify-between gap-4 flex-wrap">
-                            <div className="flex items-center gap-3 flex-shrink-0">
-                                <div className='w-6 h-6 bg-gray-600 rounded-full'></div>
-                                <span className="font-semibold text-primaryText text-lg">{position.token}</span>
-                                <span className={`text-xs font-medium px-2 py-0.5 rounded ${position.type === 'Long' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-red-500/20 text-red-400'}`}>
-                                    {position.type}
-                                </span>
-                            </div>
+                    positions.map((position) => {
+                        const formattedFeedId = position.price_feed_id_bytes.startsWith('0x')
+                            ? position.price_feed_id_bytes
+                            : `0x${position.price_feed_id_bytes}`;
+                        const livePrice = livePrices[formattedFeedId];
+                        const liveValue = calculatePositionValue(position, livePrice);
+                        const formattedAmount = formatAmount(position.amount, 6);
 
-                            <div className="flex-grow grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2 text-sm">
-                                <div>
-                                    <span className="text-secondaryText block">Value</span>
-                                    <span className="text-primaryText font-medium">{position.value}</span>
+                        return (
+                            <div key={position.position_id} className="card bg-backgroundOffset p-4 rounded-lg flex flex-col sm:flex-row sm:items-center justify-between gap-4 flex-wrap">
+                                <div className="flex items-center gap-3 flex-shrink-0">
+                                    <div className='w-6 h-6 bg-gray-600 rounded-full'></div>
+                                    <span className="font-semibold text-primaryText text-lg">
+                                        Token Index {position.supported_positions_token_i}
+                                    </span>
+                                    <span className={`text-xs font-medium px-2 py-0.5 rounded ${position.position_type === 'Long' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-red-500/20 text-red-400'}`}>
+                                        {position.position_type}
+                                    </span>
                                 </div>
-                                <div>
-                                    <span className="text-secondaryText block">Leverage</span>
-                                    <span className="text-primaryText font-medium">{position.leverage}x</span>
-                                </div>
-                                <div className="col-span-2 sm:col-span-1">
-                                    <span className="text-secondaryText block">Amount</span>
-                                    <span className="text-primaryText font-medium">{position.amount}</span>
-                                </div>
-                            </div>
 
-                            <button 
-                                className="btn-action text-sm py-2 px-4 flex-shrink-0 w-full sm:w-auto"
-                                onClick={() => openModal(position.id)}
-                            > 
-                                Close
-                            </button>
-                        </div>
-                    ))
+                                <div className="flex-grow grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2 text-sm">
+                                    <div>
+                                        <span className="text-secondaryText block">Value</span>
+                                        <span className="text-primaryText font-medium">
+                                            {formatCurrency(liveValue)}
+                                            {livePrice === undefined && <span className="text-xs text-secondaryText"> (Loading...)</span>}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span className="text-secondaryText block">Leverage</span>
+                                        <span className="text-primaryText font-medium">{position.leverage_multiplier}x</span>
+                                    </div>
+                                    <div className="col-span-2 sm:col-span-1">
+                                        <span className="text-secondaryText block">Amount</span>
+                                        <span className="text-primaryText font-medium">{formattedAmount}</span>
+                                    </div>
+                                </div>
+
+                                <button
+                                    className="btn-action text-sm py-2 px-4 flex-shrink-0 w-full sm:w-auto"
+                                    onClick={() => openModal(position.position_id)}
+                                >
+                                    Close
+                                </button>
+                            </div>
+                        );
+                    })
                 )}
             </div>
 
             {isModalOpen && positionToClose && (
-                <div 
+                <div
                     className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50 p-4"
-                    onClick={closeModal}
                 >
-                    <div 
-                        className="card bg-backgroundOffset p-6 rounded-lg shadow-xl w-full max-w-md border border-secondary"
+                    <div
+                        className="card bg-backgroundOffset p-6 shadow-xl w-full max-w-md border border-secondary"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <h3 className="text-lg font-semibold text-primaryText mb-4">
-                            Close {positionToClose.token} {positionToClose.type} Position
+                            Close {positionToClose.supported_positions_token_i} {positionToClose.position_type} Position
                         </h3>
-                        
-                        <div className="mb-4">
+
+                        <div className="mb-1">
                             <label className="input-label block text-secondaryText mb-2" htmlFor="modal-close-amount">
-                                Amount to Close (Max: {positionToClose.amount}) 
+                                {/* Display max amount with correct decimals */}
+                                Amount to Close (Max: {totalPositionAmount.toFixed(AMOUNT_DECIMALS)})
                             </label>
                             <div className="flex gap-5 justify-between px-4 py-3 mt-2 bg-mainBackground rounded-lg">
                                 <input
                                     id="modal-close-amount"
-                                    type="text"
+                                    type="text" // Use text to allow intermediate states like "."
+                                    inputMode="decimal" // Hint for mobile keyboards
                                     className="input-field bg-transparent p-0 my-auto w-full text-primaryText focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none focus:placeholder-transparent"
                                     value={modalCloseAmount}
                                     onChange={handleModalAmountChange}
-                                    placeholder="0.00"
+                                    placeholder={`0.${'0'.repeat(AMOUNT_DECIMALS)}`} // Dynamic placeholder based on decimals
                                 />
                             </div>
+                            {modalAmountError && (
+                                <p className="text-red-500 text-xs mt-1">{modalAmountError}</p>
+                            )}
                         </div>
 
-                        <div className="mb-4">
+                        <div className="mb-4 mt-3">
                             <label className="input-label block text-secondaryText mb-2">
                                 Percentage: <span className="text-primaryText font-medium">{closePercentage.toFixed(0)}%</span>
                             </label>
-                            <Slider 
-                                value={closePercentage} 
-                                onChange={handleSliderChange} 
+                            <Slider
+                                value={closePercentage}
+                                onChange={handleSliderChange}
                             />
-                        </div>
-
-                        <div className="text-sm text-secondaryText">
-                            Value to Close: <span className="text-primaryText font-medium">${valueToClose.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                            {/* Display the calculated closing value */}
+                            <div className="text-sm text-secondaryText mt-2">
+                                {/* Ensure closingValue calculation uses the parsed modal amount */}
+                                Closing Value: <span className="text-primaryText font-medium">{formatCurrency(positionToCloseLiveValue !== null ? positionToCloseLiveValue * (closePercentage / 100) : null)}</span>
+                            </div>
                         </div>
 
                         <div className="flex gap-4 mt-6">
-                            <button 
+                            <button
                                 className="btn-secondary flex-1 py-2 px-4"
                                 onClick={closeModal}
                             >
                                 Cancel
                             </button>
-                            <button 
-                                className="btn-action flex-1 py-2 px-4" 
+                            <button
+                                className="btn-action flex-1 py-2 px-4"
                                 onClick={handleConfirmClose}
-                                disabled={!modalCloseAmount || parseFloat(modalCloseAmount) <= 0}
+                                // Disable confirm if there's an error, amount is empty, zero, negative, or exceeds max (redundant check, but safe)
+                                disabled={!!modalAmountError || !modalCloseAmount || parseFloat(modalCloseAmount) <= 0 || parseFloat(modalCloseAmount) > totalPositionAmount || isLoading}
                             >
                                 Confirm Close
                             </button>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,3 +6,17 @@ export interface VaultData {
   coin_type: string;  // Type of the underlying coin, e.g., 0x...::btc::BTC
   value: number;      // USD value of the coins held in the vault
 }
+
+export interface PositionData {
+  transaction_hash: string;
+  position_id: string;
+  position_type: "Long" | "Short";
+  amount: string; // Amount is likely a large integer string
+  leverage_multiplier: string; // Leverage is a string
+  entry_price: string; // Entry price is a string
+  entry_price_decimals: number; // Decimals for entry price
+  supported_positions_token_i: number; // Index for the token
+  price_feed_id_bytes: string;
+  account_id: string;
+  timestamp: string;
+}

--- a/frontend/src/utils/pythPriceFeed.ts
+++ b/frontend/src/utils/pythPriceFeed.ts
@@ -3,69 +3,77 @@ import { HermesClient } from "@pythnetwork/hermes-client";
 // Mapping of common assets to their Pyth price feed IDs
 export const PRICE_FEED_IDS: Record<string, string> = {
   // Cryptocurrency pairs
-  'BTCUSD': '0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
-  'ETHUSD': '0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace',
-  'SOLUSD': '0xef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d',
-  'AVAXUSD': '0x93da3352f9f1d105fdfe4971cfa80e9dd777bfc5d0f683ebb6e1294b92137bb7',
-  'MATICUSD': '0x5de33a9112c2b700b8d30b8a3402c103578ccfa2765696471cc672bd5cf6ac52',
-  'LINKUSD': '0x8ac0c70fff57e9aefdf5edf44b51d62c2d433653cbb2cf5cc06bb115af04d221',
-  'DOGEUSD': '0xdcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c',
-  'UNIUSD': '0x78d185a741d7b3e43748f63e2ffbb10bd8d575e9cad8e6159daa2a60f5c68c17'
+  'BTCUSD': '0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b',
+  'ETHUSD': '0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6'
 };
 
 // Class to manage Pyth price feed subscriptions
 export class PythPriceFeedService {
   private client: HermesClient;
   private activeSubscriptions: Map<string, () => void> = new Map();
-  
+  private priceCache: Map<string, { price: number, confidence: number }> = new Map(); // Cache latest prices
+
   constructor() {
     // Use the mainnet endpoint
-    this.client = new HermesClient("https://hermes.pyth.network");
+    this.client = new HermesClient("https://hermes-beta.pyth.network");
   }
-  
-  // Subscribe to price updates for a specific asset symbol
+
+  // Subscribe to price updates for a specific asset symbol or price feed ID
   async subscribe(
-    symbol: string, 
+    symbolOrId: string, // Can be a symbol like 'BTCUSD' or a price feed ID like '0x...'
     onPriceUpdate: (price: number, confidence: number) => void
   ): Promise<boolean> {
     try {
-      // Check if we already have an active subscription for this symbol
-      if (this.activeSubscriptions.has(symbol)) {
-        console.warn(`Already subscribed to ${symbol}`);
+      // Check if we already have an active subscription for this symbol/ID
+      if (this.activeSubscriptions.has(symbolOrId)) {
+        console.warn(`Already subscribed to ${symbolOrId}`);
+        // If already subscribed, immediately call back with cached price if available
+        const cachedPrice = this.priceCache.get(symbolOrId);
+        if (cachedPrice) {
+            onPriceUpdate(cachedPrice.price, cachedPrice.confidence);
+        }
         return false;
       }
-      
-      // Get the price feed ID for this symbol
-      const priceId = PRICE_FEED_IDS[symbol];
+
+      // Determine the price feed ID
+      let priceId: string | undefined;
+      if (symbolOrId.startsWith('0x')) {
+        priceId = symbolOrId; // Assume it's a direct ID
+      } else {
+        priceId = PRICE_FEED_IDS[symbolOrId]; // Look up symbol
+      }
+
       if (!priceId) {
-        console.error(`No price feed ID found for ${symbol}`);
+        console.error(`No price feed ID found or provided for ${symbolOrId}`);
         return false;
       }
-      
+
       // Get an event source for price updates
       const eventSource = await this.client.getPriceUpdatesStream([priceId], {
         parsed: true,
         allowUnordered: false
       });
-      
+
       // Set up event handlers
       eventSource.onmessage = (event) => {
         try {
           // Parse the price update from the event data
           const data = JSON.parse(event.data);
-          
+
           // Extract price info from the parsed data structure
           if (data.parsed && Array.isArray(data.parsed) && data.parsed.length > 0) {
             const priceUpdate = data.parsed[0]; // Get the first parsed price update
-            
+
             // Extract price data from the price object
             const priceObj = priceUpdate.price;
-            
+
             // Calculate the actual price using the exponent
-            // Pyth prices are represented as a price and a confidence interval, both scaled by a negative exponent
             const price = Number(priceObj.price) * (10 ** priceObj.expo);
             const confidence = Number(priceObj.conf) * (10 ** priceObj.expo);
-            
+
+            // Cache the latest price
+            this.priceCache.set(symbolOrId, { price, confidence });
+
             // Call the callback with the formatted price data
             onPriceUpdate(price, confidence);
           } else {
@@ -75,110 +83,137 @@ export class PythPriceFeedService {
           console.error('Error processing price update:', error);
         }
       };
-      
+
       // Handle errors
       eventSource.onerror = (error) => {
-        console.error(`Error in price update stream for ${symbol}:`, error);
+        console.error(`Error in price update stream for ${symbolOrId}:`, error);
+        // Optionally attempt to reconnect or handle the error
       };
-      
+
       // Return a function to close the event source
       const unsubscribe = () => {
         eventSource.close();
+        this.priceCache.delete(symbolOrId); // Clear cache on unsubscribe
       };
-      
+
       // Store the unsubscribe function for later cleanup
-      this.activeSubscriptions.set(symbol, unsubscribe);
-      
-      console.log(`Subscribed to ${symbol} price feed`);
+      this.activeSubscriptions.set(symbolOrId, unsubscribe);
+
+      console.log(`Subscribed to ${symbolOrId} price feed`);
+      // Fetch initial price immediately after subscribing
+      this.getLatestPrice(symbolOrId).then(initialPrice => {
+        if (initialPrice) {
+            this.priceCache.set(symbolOrId, initialPrice); // Cache initial price
+            onPriceUpdate(initialPrice.price, initialPrice.confidence);
+        }
+      });
       return true;
     } catch (error) {
-      console.error('Error subscribing to price feed:', error);
+      console.error(`Error subscribing to price feed ${symbolOrId}:`, error);
       return false;
     }
   }
-  
-  // Unsubscribe from price updates for a specific asset symbol
-  async unsubscribe(symbol: string): Promise<boolean> {
+
+  // Unsubscribe from price updates for a specific asset symbol or price feed ID
+  async unsubscribe(symbolOrId: string): Promise<boolean> {
     try {
-      const unsubscribe = this.activeSubscriptions.get(symbol);
+      const unsubscribe = this.activeSubscriptions.get(symbolOrId);
       if (unsubscribe) {
         unsubscribe(); // Call the unsubscribe function
-        this.activeSubscriptions.delete(symbol);
-        console.log(`Unsubscribed from ${symbol} price feed`);
+        this.activeSubscriptions.delete(symbolOrId);
+        this.priceCache.delete(symbolOrId); // Ensure cache is cleared
+        console.log(`Unsubscribed from ${symbolOrId} price feed`);
         return true;
       }
-      
-      console.warn(`No active subscription found for ${symbol}`);
+
+      console.warn(`No active subscription found for ${symbolOrId}`);
       return false;
     } catch (error) {
-      console.error('Error unsubscribing from price feed:', error);
+      console.error(`Error unsubscribing from price feed ${symbolOrId}:`, error);
       return false;
     }
   }
-  
-  // Get the latest price for a symbol (one-time fetch)
-  async getLatestPrice(symbol: string): Promise<{ price: number, confidence: number } | null> {
+
+  // Get the latest price for a symbol or price feed ID (one-time fetch)
+  async getLatestPrice(symbolOrId: string): Promise<{ price: number, confidence: number } | null> {
+    // Check cache first
+    const cachedPrice = this.priceCache.get(symbolOrId);
+    if (cachedPrice) {
+        return cachedPrice;
+    }
+
     try {
-      const priceId = PRICE_FEED_IDS[symbol];
+      // Determine the price feed ID
+      let priceId: string | undefined;
+      if (symbolOrId.startsWith('0x')) {
+        priceId = symbolOrId; // Assume it's a direct ID
+      } else {
+        priceId = PRICE_FEED_IDS[symbolOrId]; // Look up symbol
+      }
+
       if (!priceId) {
-        console.error(`No price feed ID found for ${symbol}`);
+        console.error(`No price feed ID found or provided for ${symbolOrId}`);
         return null;
       }
-      
+
       // Get the latest price updates
       const priceUpdates = await this.client.getLatestPriceUpdates([priceId]);
-      
+
       // Check if priceUpdates is an object with parsed data
-      if (priceUpdates && 
-          typeof priceUpdates === 'object' && 
-          'parsed' in priceUpdates && 
-          Array.isArray(priceUpdates.parsed) && 
+      if (priceUpdates &&
+          typeof priceUpdates === 'object' &&
+          'parsed' in priceUpdates &&
+          Array.isArray(priceUpdates.parsed) &&
           priceUpdates.parsed.length > 0) {
-        
+
         const priceUpdate = priceUpdates.parsed[0];
-        
+
         // Make sure the price update has the price object with required fields
         if (
-          typeof priceUpdate === 'object' && 
+          typeof priceUpdate === 'object' &&
           priceUpdate !== null &&
-          'price' in priceUpdate && 
+          'price' in priceUpdate &&
           typeof priceUpdate.price === 'object' &&
           'price' in priceUpdate.price &&
           'conf' in priceUpdate.price &&
           'expo' in priceUpdate.price
         ) {
           const priceObj = priceUpdate.price;
-          
+
           // Calculate actual price using the exponent
           const price = Number(priceObj.price) * (10 ** Number(priceObj.expo));
           const confidence = Number(priceObj.conf) * (10 ** Number(priceObj.expo));
-          
+
+          // Cache the fetched price
+          this.priceCache.set(symbolOrId, { price, confidence });
+
           return { price, confidence };
         }
       }
-      
+
       return null;
     } catch (error) {
-      console.error('Error fetching latest price:', error);
+      console.error(`Error fetching latest price for ${symbolOrId}:`, error);
       return null;
     }
   }
-  
+
   // Clean up all subscriptions
   cleanup(): void {
     // Convert Map entries to array to avoid TypeScript iterating issues
     const subscriptions = Array.from(this.activeSubscriptions.entries());
-    
-    subscriptions.forEach(([symbol, unsubscribe]) => {
+
+    subscriptions.forEach(([symbolOrId, unsubscribe]) => {
       try {
         unsubscribe();
-        console.log(`Unsubscribed from ${symbol} price feed during cleanup`);
+        console.log(`Unsubscribed from ${symbolOrId} price feed during cleanup`);
       } catch (error) {
-        console.error(`Error during cleanup:`, error);
+        console.error(`Error during cleanup for ${symbolOrId}:`, error);
       }
     });
-    
+
     this.activeSubscriptions.clear();
+    this.priceCache.clear(); // Clear cache on cleanup
   }
 }
 


### PR DESCRIPTION
Frontend v1.7.5
- Moves PositionData to types.ts, with fields that reflect the event fields
- Positions are now populated from the indexer
- Uses the pythPriceFeed service to get prices for all position coins
- Modal for closing a position shows the value (based on percentage selected)

NOTE: Decimals for amount are currently hardcoded to 6. PP-115 and -116 have been filed to handle this