### PR TITLE
[PP-138] Require Wallet Connection Before Displaying Account Health

### DIFF
--- a/frontend/src/components/trading/AccountHealth.tsx
+++ b/frontend/src/components/trading/AccountHealth.tsx
@@ -3,10 +3,12 @@ import React from "react";
 
 interface AccountHealthProps {
   accountHealthPercentage: number;
+  hasAccountInfo: boolean;
 }
 
 const AccountHealth: React.FC<AccountHealthProps> = ({
   accountHealthPercentage,
+  hasAccountInfo,
 }) => {
 
   const textualDisplayPercentage = Number(accountHealthPercentage.toFixed(2));
@@ -15,13 +17,23 @@ const AccountHealth: React.FC<AccountHealthProps> = ({
   return (
     <section className="card border border-secondary">
       <h2 className="header-title">Account Health</h2>
-      <div className="progress-container">
-        <div
-          className="progress-bar"
-          style={{ width: `${progressBarPercentage}%` }}
-        />
-      </div>
-      <p className="text-value">{textualDisplayPercentage}%</p>
+      {hasAccountInfo ? (
+        <>
+          <div className="progress-container">
+            <div
+              className="progress-bar"
+              style={{ width: `${progressBarPercentage}%` }}
+            />
+          </div>
+          <p className="text-value">{textualDisplayPercentage}%</p>
+        </>
+      ) : (
+        <div className="flex items-center justify-center py-8">
+          <p className="text-center text-gray-400">
+            Connect a wallet to see account health
+          </p>
+        </div>
+      )}
     </section>
   );
 };

--- a/frontend/src/components/trading/TradingPlatform.tsx
+++ b/frontend/src/components/trading/TradingPlatform.tsx
@@ -960,6 +960,7 @@ const TradingPlatform: React.FC = () => {
             <aside className="trading-sidebar lg:col-span-1 flex flex-col gap-4">
               <AccountHealth
                 accountHealthPercentage={accountHealthPercentage}
+                hasAccountInfo={connectionStatus === 'connected' && !!account && !!accountObjectId}
               />
               <ActionTabs
                 account={account}


### PR DESCRIPTION
- Displays a message to connect wallet in the account health widget, as opposed to showing a 100% health.