### PR TITLE
[PP-208] Fix Truncation of PriceFeed IDs (+ Copy)

### DIFF
--- a/frontend/src/components/oracle-builder/Build.tsx
+++ b/frontend/src/components/oracle-builder/Build.tsx
@@ -26,7 +26,6 @@ interface OracleFormData {
     id: string
     name: string
     description: string
-    feedId: string
     api_key: string
     underlying_url: string
     response_field: string
@@ -52,7 +51,6 @@ export default function BuildOracle({ onNavigate }: BuildOracleProps) {
     id: string
     name: string
     description: string
-    feedId: string
     api_key: string
     underlying_url: string
     response_field: string

--- a/frontend/src/components/oracle-builder/ManagePriceFeeds.tsx
+++ b/frontend/src/components/oracle-builder/ManagePriceFeeds.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Plus, Database } from "lucide-react"
+import { Plus, Database, Copy, Check } from "lucide-react"
 import { UIOracle, UIPriceFeed } from "@/types/oracleBuilder"
 
 interface ManagePriceFeedProps {
@@ -18,7 +18,28 @@ export const ManagePriceFeeds: React.FC<ManagePriceFeedProps> = ({
   setSelectedPriceFeedId,
   handleNavigateToConfigure,
 }) => {
+  const [copiedFeedId, setCopiedFeedId] = React.useState<boolean>(false);
   const selectedFeed = oracle?.priceFeeds.find((feed) => feed.id === selectedPriceFeedId)
+
+  // Reset copied state when selected price feed changes
+  React.useEffect(() => {
+    setCopiedFeedId(false);
+  }, [selectedPriceFeedId]);
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedFeedId(true);
+      setTimeout(() => setCopiedFeedId(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  const abbreviateFeedId = (feedId: string) => {
+    if (feedId.length <= 30) return feedId;
+    return `${feedId.slice(0, 24)}...`;
+  };
 
   return (
     <Card className="bg-gray-900 border-gray-800">
@@ -77,11 +98,25 @@ export const ManagePriceFeeds: React.FC<ManagePriceFeedProps> = ({
               <div className="space-y-4">
                 <div>
                   <label className="text-xs font-medium text-gray-400">Price Feed ID:</label>
-                  <Input
-                    className="bg-gray-800 border-gray-700 text-gray-300 mt-1 cursor-not-allowed"
-                    value={selectedFeed.feedId}
-                    disabled
-                  />
+                  <div className="relative mt-1">
+                    <Input
+                      className="bg-gray-800 border-gray-700 text-gray-300 pr-10 cursor-not-allowed"
+                      value={abbreviateFeedId(selectedFeed.id)}
+                      disabled
+                      title={selectedFeed.id}
+                    />
+                    <button
+                      onClick={() => copyToClipboard(selectedFeed.id)}
+                      className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-gray-700 rounded transition-colors"
+                      title="Copy full ID to clipboard"
+                    >
+                      {copiedFeedId ? (
+                        <Check className="w-4 h-4 text-green-400" />
+                      ) : (
+                        <Copy className="w-4 h-4 text-gray-400 hover:text-gray-300" />
+                      )}
+                    </button>
+                  </div>
                 </div>
                 <div>
                   <label className="text-xs font-medium text-gray-400">Underlying URL:</label>

--- a/frontend/src/components/oracle-builder/PriceFeeds.tsx
+++ b/frontend/src/components/oracle-builder/PriceFeeds.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { ExternalLink } from "lucide-react"
+import { ExternalLink, Copy, Check } from "lucide-react"
 
 interface PriceFeedsProps {
   selectedOracle: any
@@ -11,6 +11,7 @@ interface PriceFeedsProps {
 
 const PriceFeeds: React.FC<PriceFeedsProps> = ({ selectedOracle }) => {
   const [selectedPriceFeed, setSelectedPriceFeed] = React.useState<string>("");
+  const [copiedFeedId, setCopiedFeedId] = React.useState<boolean>(false);
 
   // When the oracle changes, immediately reset selected price feed to the new oracle's first feed
   React.useEffect(() => {
@@ -21,7 +22,27 @@ const PriceFeeds: React.FC<PriceFeedsProps> = ({ selectedOracle }) => {
     }
   }, [selectedOracle]);
 
+  // Reset copied state when selected price feed changes
+  React.useEffect(() => {
+    setCopiedFeedId(false);
+  }, [selectedPriceFeed]);
+
   const selectedFeed = selectedOracle?.priceFeeds.find((feed: any) => feed.id === selectedPriceFeed);
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedFeedId(true);
+      setTimeout(() => setCopiedFeedId(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  const abbreviateFeedId = (feedId: string) => {
+    if (feedId.length <= 30) return feedId;
+    return `${feedId.slice(0, 24)}...`;
+  };
 
   return (
     <Card className="bg-gray-900 border-gray-800">
@@ -60,11 +81,25 @@ const PriceFeeds: React.FC<PriceFeedsProps> = ({ selectedOracle }) => {
               <div className="space-y-4">
                 <div>
                   <label className="text-xs font-medium text-gray-400">Price Feed ID:</label>
-                  <Input
-                    className="bg-gray-800 border-gray-700 text-gray-300 mt-1 cursor-not-allowed"
-                    value={selectedFeed.feedId}
-                    disabled
-                  />
+                  <div className="relative mt-1">
+                    <Input
+                      className="bg-gray-800 border-gray-700 text-gray-300 pr-10 cursor-not-allowed"
+                      value={abbreviateFeedId(selectedFeed.id)}
+                      disabled
+                      title={selectedFeed.id}
+                    />
+                    <button
+                      onClick={() => copyToClipboard(selectedFeed.id)}
+                      className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-gray-700 rounded transition-colors"
+                      title="Copy full ID to clipboard"
+                    >
+                      {copiedFeedId ? (
+                        <Check className="w-4 h-4 text-green-400" />
+                      ) : (
+                        <Copy className="w-4 h-4 text-gray-400 hover:text-gray-300" />
+                      )}
+                    </button>
+                  </div>
                 </div>
                 <div>
                   <label className="text-xs font-medium text-gray-400">Underlying URL:</label>

--- a/frontend/src/components/oracle-builder/steps/ConfigureStep.tsx
+++ b/frontend/src/components/oracle-builder/steps/ConfigureStep.tsx
@@ -28,7 +28,6 @@ const ConfigureStep: React.FC<ConfigureStepProps> = ({
     id: '',
     name: '',
     description: '',
-    feedId: '',
     api_key: '',
     api_key_config: '',
     underlying_url: 'https://api.example.com/price',

--- a/frontend/src/components/oracle-builder/steps/CreateStep.tsx
+++ b/frontend/src/components/oracle-builder/steps/CreateStep.tsx
@@ -135,7 +135,7 @@ const CreateStep: React.FC<CreateStepProps> = ({
               {configuredPriceFeeds.map((feed) => (
                 <div key={feed.id} className="p-3 rounded-lg border bg-gray-800 border-gray-700">
                   <div className="font-medium text-sm text-gray-100">{feed.name}</div>
-                  <div className="text-xs text-gray-400 mt-1">{feed.feedId}</div>
+                  <div className="text-xs text-gray-400 mt-1">{feed.id}</div>
                 </div>
               ))}
             </div>

--- a/frontend/src/types/oracleBuilder.ts
+++ b/frontend/src/types/oracleBuilder.ts
@@ -92,7 +92,6 @@ export interface PriceFeedFormData {
   id: string;
   name: string;
   description: string;
-  feedId: string;
   api_key: string;
   api_key_config: string;
   underlying_url: string;
@@ -115,7 +114,6 @@ export interface UIOracle extends Oracle {
 export interface UIPriceFeed extends PriceFeed {
   name?: string;
   description?: string;
-  feedId?: string;
   isProtected?: boolean;
 }
 

--- a/frontend/src/utils/oracleDataTransforms.ts
+++ b/frontend/src/utils/oracleDataTransforms.ts
@@ -28,7 +28,6 @@ export const transformPriceFeedFromApi = (apiPriceFeed: IndexerPriceFeed): UIPri
     live_url: apiPriceFeed.live_url,
     name: apiPriceFeed.name,
     description: apiPriceFeed.description,
-    feedId: apiPriceFeed.price_feed_id.slice(0, 16),
     isProtected: false, // Default - could be derived from other data
   };
 };


### PR DESCRIPTION
- Removes unnecessary field to pricefeed types that contained a truncated ID.
- UI displays proper ID now
- Added copy functionality in case the ID is needed by the user